### PR TITLE
pam: add support for SSH remote login

### DIFF
--- a/src/pam.c
+++ b/src/pam.c
@@ -72,7 +72,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags,
 	if (pam_get_item(pamh, PAM_TTY,
 				(const void **)(const void *)&tty) == PAM_SUCCESS)
 	{
-		if (tty && !strcmp(tty, "ssh"))
+		if (tty && (!strcmp(tty, "ssh") && !strcmp(tty, "sshd")))
 		{
 			log_debug("SSH Authentication, aborting.\n");
 			return (PAM_AUTH_ERR);


### PR DESCRIPTION
In the newer version of Centos8 and other systems, sshd is used as the background service for SSH remote login access. It is used to verify and calculate the session and so on, so it needs to be released.

Signed-off-by: Li kunyu <kunyu@nfschina.com>